### PR TITLE
[ res-middleware-ADD ] auth-middleware를 구현하라

### DIFF
--- a/05_restaurant/middleware.ts
+++ b/05_restaurant/middleware.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as jose from "jose";
+
+export default async function middleware(req: NextRequest, res: NextResponse) {
+
+  const bearerToken = req.headers.get("authorization") as string;
+  if (!bearerToken) {
+    return new NextResponse(
+      JSON.stringify({errorMessage:"인증되지 않은 요청입니다. 토큰이 없습니다."}), { status:401}
+    )
+  }
+
+  const token = bearerToken.split(" ")[1];
+  if (!token) {
+    return new NextResponse(
+      JSON.stringify({errorMessage:"인증되지 않은 요청입니다. 토큰이 없습니다."}), { status:401}
+    )
+  }
+
+  const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+  try {
+    // jose로 token이 유효한지 확인한다
+    await jose.jwtVerify(token, secret);
+  } catch (error) {
+    // token이 일치하지 않으면 Error발생
+    return new NextResponse(
+      JSON.stringify({errorMessage:"인증되지 않은 요청입니다. 토큰이 없습니다."}), { status:401}
+    )
+  }
+}
+
+// middleware를 선택적으로 사용할 수 있다 
+export const config = {
+  matcher: ["/api/auth/me"],
+};


### PR DESCRIPTION
- auth와 관련된 serverAPI 요청에만 middleware를 요청하고 싶어서 export config로 추가설정 하였다
- middleware는 server로 API요청이 도착하기 전 실행되는 기능이다. 로그인/ 회원가입 요청 전에 사용자가 입력한 데이터와 token을 검증하는 구간이다.